### PR TITLE
Support for python 3.x using pillow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ TesseractTrainer intends to provide both a python API and a bash command line to
 
 * a Unix/Linux system
 * Tesseract3.01 (Tesseract 3.02 compatibility is on the way)
-* python 2.6 - 2.7
-* PIL (Python Imaging Library). Note that PIL has not yet been ported to Python 3.
+* python 2.6 - 2.7, 3.2 - 3.3
+* Pillow (Python Imaging Library fork)
+  Following libraries should be already installed before Pillow installation
+    * libjpeg62
+    * libjpeg-dev
+    * libfreetype6
+    * libfreetype6-dev
+    * zlib1g-dev
+  otherwise, some freetype/zlib/jpeg operations will not be supported.
 * ImageMagick
 
 ## Installation

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email='rouberol.b@gmail.com',
     url='https://github.com/BaltoRouberol/TesseractTrainer',
     packages=['tesseract_trainer'],
-    install_requires=['PIL>=1.1.7'],
+    install_requires=['Pillow>=2.0.0'],
     keywords=['tesseract', 'OCR', 'optical character recogniton', 'training'],
     scripts=['tesseract_trainer/tesstrain'],
     classifiers=[
@@ -32,6 +32,8 @@ setup(
            'Operating System :: MacOS :: MacOS X',
            'Programming Language :: Python :: 2.6',
            'Programming Language :: Python :: 2.7',
+           'Programming Language :: Python :: 3.2',
+           'Programming Language :: Python :: 3.3',
            'Topic :: Scientific/Engineering :: Artificial Intelligence',
            'Topic :: Scientific/Engineering :: Image Recognition',
         ],

--- a/tesseract_trainer/multipage_tif.py
+++ b/tesseract_trainer/multipage_tif.py
@@ -9,9 +9,18 @@ and page number.
 UTF-8 encoded characters are supported.
 """
 
-import Image
-import ImageFont
-import ImageDraw
+import sys
+
+if sys.version_info >= (3,):
+    # Install Pillow which supports python 3.x
+    from PIL import Image
+    from PIL import ImageFont
+    from PIL import ImageDraw
+else:
+    import Image
+    import ImageFont
+    import ImageDraw
+
 import glob
 import subprocess
 import os

--- a/tesseract_trainer/multipage_tif.py
+++ b/tesseract_trainer/multipage_tif.py
@@ -11,20 +11,13 @@ UTF-8 encoded characters are supported.
 
 import sys
 
-if sys.version_info >= (3,):
-    # Install Pillow which supports python 3.x
-    from PIL import Image
-    from PIL import ImageFont
-    from PIL import ImageDraw
-else:
-    import Image
-    import ImageFont
-    import ImageDraw
+from PIL import Image
+from PIL import ImageFont
+from PIL import ImageDraw
 
 import glob
 import subprocess
 import os
-import sys
 
 
 


### PR DESCRIPTION
Have verified that same modules are available in pillow, but was not able to verify due to unavailability of tesseract setup.Please test before pulling the code.
